### PR TITLE
ci: fix tag check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - images/**
 
 jobs:
   find-changed-files:
@@ -68,9 +70,9 @@ jobs:
       - name: Correct tag of image
         run: |
           TAG=$(basename "${{ matrix.dockerfile }}")
-          if [[ "$TAG" != "v"* ]]; then
+          if ! [[ "$TAG" =~ [0-9] ]]; then
             exit 1
-          fi  
+          fi
 
   hadolint:
     needs: find-changed-files


### PR DESCRIPTION
сейчас ci допускает только папочку начинающуюся с `v...`, однако у нас очень много тегов начинающихся без `v`
из-за этого переделала проверку на то, что папка, обозначающая тэг, просто включает в себя цифры 